### PR TITLE
Fix bug with string default

### DIFF
--- a/src/components/GenerateMutation.js
+++ b/src/components/GenerateMutation.js
@@ -12,7 +12,7 @@ const basicTypesDefaultValues = {
   Float: 0.0,
   ID: '',
   Int: 0,
-  String: '',
+  String: '""',
   Boolean: false,
 };
 

--- a/src/components/GenerateMutation.js
+++ b/src/components/GenerateMutation.js
@@ -12,7 +12,7 @@ const basicTypesDefaultValues = {
   Float: 0.0,
   ID: '',
   Int: 0,
-  String: '""',
+  String: '"YOUR_VALUE"',
   Boolean: false,
 };
 


### PR DESCRIPTION
The default string type should be `""`

With a mutation schema like this:
```
const createThing = {
  type: ThingType.Thing,
  description: 'Create Thing',
  args: {
    uuid: {
      description: 'Thing UUID',
      type: graphql.GraphQLString
    }
  },
  resolve: (whatever) => doSomething()
};
```
the UI fails with this error:
```
"Syntax Error GraphQL (3:42) Unexpected )
1:
2:       mutation createThingMutation {
3:         createThing(uuid: ) {
                             ^
4:           name  ,token  

```

The generated mutation should be:
```
mutation createThingMutation {
  createThing(uuid: "") {
    name
    token
  }
}
```
